### PR TITLE
Simplify build script; format with rustfmt

### DIFF
--- a/common.rs
+++ b/common.rs
@@ -4,7 +4,7 @@
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 /// Information specific to architecture
-struct CapstoneArchInfo<'a> {
+pub struct CapstoneArchInfo<'a> {
     /// name of C header
     header_name: &'a str,
 
@@ -12,7 +12,7 @@ struct CapstoneArchInfo<'a> {
     cs_name: &'a str,
 }
 
-static ARCH_INCLUDES: &'static [CapstoneArchInfo<'static>] = &[
+pub static ARCH_INCLUDES: &'static [CapstoneArchInfo<'static>] = &[
     CapstoneArchInfo {
         header_name: "arm.h",
         cs_name: "arm",
@@ -47,4 +47,4 @@ static ARCH_INCLUDES: &'static [CapstoneArchInfo<'static>] = &[
     },
 ];
 
-static BINDINGS_FILE: &'static str = "capstone.rs";
+pub static BINDINGS_FILE: &'static str = "capstone.rs";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@
 //! * `struct cs_ARCH_op`: instruction operand
 //! * `struct cs_ARCH`: instruction
 //!
-//! **Note**: documentation for functions/types was taken directly from [Capstone C headers][capstone headers].
+//! **Note**: documentation for functions/types was taken directly from
+//! [Capstone C headers][capstone headers].
 //!
 //! [capstone headers]: https://github.com/capstone-rust/capstone-sys/blob/master/capstone/include/capstone.h
 //! <sup>1</sup>: Defined as a ["constified" enum modules](https://docs.rs/bindgen/0.30.0/bindgen/struct.Builder.html#method.constified_enum_module)
@@ -45,15 +46,7 @@
 
 use std::os::raw::c_int;
 
-// Include pre-generated bindgen bindings
-#[cfg(not(feature = "use_bindgen"))]
-include!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/pre_generated/capstone.rs"
-));
-
-// Include dynamically generated bindings
-#[cfg(feature = "use_bindgen")]
+// Bindings should be copied here
 include!(concat!(env!("OUT_DIR"), "/capstone.rs"));
 
 pub const CS_SUPPORT_DIET: c_int = (cs_arch::CS_ARCH_ALL as c_int) + 1;
@@ -222,9 +215,7 @@ mod test {
         // Union structs
         let op = cs_ppc_op {
             type_: ppc_op_type::PPC_OP_REG,
-            __bindgen_anon_1: cs_ppc_op__bindgen_ty_1 {
-                reg: ppc_reg::PPC_REG_CARRY,
-            },
+            __bindgen_anon_1: cs_ppc_op__bindgen_ty_1 { reg: ppc_reg::PPC_REG_CARRY },
         };
         cs_ppc {
             bc: ppc_bc::PPC_BC_LT,
@@ -327,9 +318,7 @@ mod test {
         // Union types
         let op = cs_x86_op {
             type_: x86_op_type::X86_OP_REG,
-            __bindgen_anon_1: cs_x86_op__bindgen_ty_1 {
-                reg: x86_reg::X86_REG_AH,
-            },
+            __bindgen_anon_1: cs_x86_op__bindgen_ty_1 { reg: x86_reg::X86_REG_AH },
             size: 0,
             avx_bcast: x86_avx_bcast::X86_AVX_BCAST_2,
             avx_zero_opmask: false,


### PR DESCRIPTION
Eliminates some of the messy `[cfg(feature ...)]` constructs.