### PR TITLE
Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ bindgen = { optional = true, version = "0.30.0" }
 pkg-config = { optional = true, version = "0.3" }
 cmake = {optional = true, version = "0.1.2"}
 
+[target.'cfg(windows)'.build-dependencies]
+gcc = "0.3.54"
+
 [features]
 # use bundled capstone by default instead of the system capstone
 # use pre-generated bindings instead of dynamically with bindgen


### PR DESCRIPTION
I added Windows compilation support. I used the [*gcc*](https://crates.io/crates/gcc) crate instead of *CMake* or the *Visual Studio* solution provided by *Capstone*. This has the following advantages:

- No dependency on *CMake* or *Visual Studio*. This ensures that there are no additional build requirements. If you can build regular *Rust* programs, you can build this crate.
- Both *GNU* and *MSVC* flavors of the Rust toolchain work without any changes.
- The `crt-static` *Rust* feature flag is handled correctly, when it is set the *MSVC* compiler is invoked with `/MT` instead of `/MD`.

The downside to this approach is of course that there is another build script to maintain. If the *Capstone* lib changes the Windows build may break.

I have tested `examples/demo.rs` from the `capstone-rs` crate with the following toolchains:

- `stable-x86_64-pc-windows-msvc`
- `stable-i686-pc-windows-msvc`
- `stable-x86_64-pc-windows-gnu`